### PR TITLE
feat: add option to auto activate element on mouse enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Any item can be `disabled` for prevent selection. For disable an item add the pr
 | noResultsFound | string | `'No results found'` | The default text showed when a search has no results |
 | size | `'small'/'default'/'large'` | `'default'` | Adding bootstrap classes: form-control-sm, input-sm, form-control-lg input-lg, btn-sm, btn-lg |
 | searchCallback | `(search: string, item: INgxSelectOption) => boolean` | `null` | The callback function for custom filtering the select list |
+| autoActiveOnMouseEnter | boolean | true | Automatically activate item when mouse enter on it |
 
 | Output  | Description |
 | ------------- | ------------- |

--- a/src/app/lib/ngx-select/ngx-select.component.html
+++ b/src/app/lib/ngx-select/ngx-select.component.html
@@ -85,7 +85,7 @@
                     'ngx-select__item_active active': isOptionActive(option, choiceItem),
                     'ngx-select__item_disabled disabled': option.disabled
                }"
-               (mouseenter)="optionActivate({
+               (mouseenter)="onMouseEnter({
                     activeOption: option,
                     filteredOptionList: optionsFiltered,
                     index: optionsFiltered.indexOf(option)

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -73,6 +73,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     @Input() public noResultsFound = 'No results found';
     @Input() public size: 'small' | 'default' | 'large' = 'default';
     @Input() public searchCallback: (search: string, item: INgxSelectOption) => boolean;
+    @Input() public autoActiveOnMouseEnter = true;
     public keyCodeToRemoveSelected = 'Delete';
     public keyCodeToOptionsOpen = 'Enter';
     public keyCodeToOptionsClose = 'Escape';
@@ -441,7 +442,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
 
     /** @internal */
     public optionActivate(navigated: INgxOptionNavigated): void {
-        if ((this.optionActive !== navigated.activeOption) &&
+        if (this.autoActiveOnMouseEnter && (this.optionActive !== navigated.activeOption) &&
             (!navigated.activeOption || !navigated.activeOption.disabled)) {
             this.optionActive = navigated.activeOption;
             this.navigated.emit(navigated);

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -1,7 +1,7 @@
 import {
     AfterContentChecked, DoCheck, Input, Output, ViewChild,
     Component, ElementRef, EventEmitter, forwardRef, HostListener, IterableDiffer, IterableDiffers, ChangeDetectorRef, ContentChild,
-    TemplateRef, Optional, Inject, InjectionToken
+    TemplateRef, Optional, Inject, InjectionToken, ChangeDetectionStrategy
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
@@ -48,6 +48,7 @@ function propertyExists(obj: Object, propertyName: string) {
     selector: 'ngx-select',
     templateUrl: './ngx-select.component.html',
     styleUrls: ['./ngx-select.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
@@ -175,7 +176,10 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
                     .filter((option: NgxSelectOption) => actualValue.indexOf(option.value) !== -1)
                     .toArray()
                     .filter((options: NgxSelectOption[]) => !_.isEqual(options, this.subjOptionsSelected.value))
-                    .subscribe((options: NgxSelectOption[]) => this.subjOptionsSelected.next(options));
+                    .subscribe((options: NgxSelectOption[]) => {
+                      this.subjOptionsSelected.next(options);
+                      this.cd.markForCheck();
+                    });
             })
             .subscribe();
 
@@ -193,7 +197,10 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
                     this.autoSelectSingleOption && flatOptions.length === 1 && !selectedOptions.length
                 );
             })
-            .subscribe((flatOptions: NgxSelectOption[]) => this.subjOptionsSelected.next(flatOptions));
+            .subscribe((flatOptions: NgxSelectOption[]) => {
+              this.subjOptionsSelected.next(flatOptions);
+              this.cd.markForCheck();
+            });
     }
 
     public setFormControlSize(otherClassNames: Object = {}, useFormControl: boolean = true) {

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -442,10 +442,17 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
 
     /** @internal */
     public optionActivate(navigated: INgxOptionNavigated): void {
-        if (this.autoActiveOnMouseEnter && (this.optionActive !== navigated.activeOption) &&
+        if ((this.optionActive !== navigated.activeOption) &&
             (!navigated.activeOption || !navigated.activeOption.disabled)) {
             this.optionActive = navigated.activeOption;
             this.navigated.emit(navigated);
+        }
+    }
+
+    /** @internal */
+    public onMouseEnter(navigated: INgxOptionNavigated): void {
+        if (this.autoActiveOnMouseEnter) {
+            this.optionActivate(navigated);
         }
     }
 


### PR DESCRIPTION
If the `autoActiveOnMouseEnter` is false then it prevents from
- auto scrolling to the next element when mouse is close to the upper or lower edge of the `choiceMenu`
- remove the `active` css class from the selected element when mouse is moved over the elements or scrolling

Switched to OnPush change detection mode
 