### PR TITLE
feat: pass search text to not found template

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ Also, you are can mix directives for reducing template:
         ({{option.data.hex}})
     </ng-template>
 
-    <ng-template ngx-select-option-not-found>
-        Not found <button (click)="addItem()">(+) Add new item</button>
+    <ng-template ngx-select-option-not-found let-input>
+        Not found <button (click)="addItem(input)">(+) Add "{{input}} as new item</button>
     </ng-template>
 </ngx-select>
 ``` 

--- a/src/app/demo/select/rich-demo.html
+++ b/src/app/demo/select/rich-demo.html
@@ -13,8 +13,8 @@
                 ({{option.data.hex}})
             </ng-template>
 
-            <ng-template ngx-select-option-not-found>
-                Nothing found
+            <ng-template ngx-select-option-not-found let-input>
+                "{{input}}" not found
             </ng-template>
 
         </ngx-select>

--- a/src/app/doc.md
+++ b/src/app/doc.md
@@ -181,8 +181,8 @@ Also, you are can mix directives for reducing template:
         ({{option.data.hex}})
     </ng-template>
 
-    <ng-template ngx-select-option-not-found>
-        Not found <button (click)="addItem()">(+) Add new item</button>
+    <ng-template ngx-select-option-not-found let-input>
+        Not found <button (click)="addItem(input)">(+) Add "{{input}} as new item</button>
     </ng-template>
 </ngx-select>
 ``` 

--- a/src/app/lib/ngx-select/ngx-select.component.html
+++ b/src/app/lib/ngx-select/ngx-select.component.html
@@ -98,7 +98,7 @@
         </li>
         <li class="ngx-select__item ngx-select__item_no-found dropdown-header" *ngIf="!optionsFiltered.length">
             <ng-container [ngTemplateOutlet]="templateOptionNotFound || defaultTemplateOptionNotFound"
-                          [ngTemplateOutletContext]="{$implicit: (inputElRef?.nativeElement?.value || '')}"></ng-container>
+                          [ngTemplateOutletContext]="{$implicit: inputText}"></ng-container>
         </li>
     </ul>
 

--- a/src/app/lib/ngx-select/ngx-select.component.html
+++ b/src/app/lib/ngx-select/ngx-select.component.html
@@ -97,7 +97,8 @@
             </a>
         </li>
         <li class="ngx-select__item ngx-select__item_no-found dropdown-header" *ngIf="!optionsFiltered.length">
-            <ng-container [ngTemplateOutlet]="templateOptionNotFound || defaultTemplateOptionNotFound"></ng-container>
+            <ng-container [ngTemplateOutlet]="templateOptionNotFound || defaultTemplateOptionNotFound"
+                          [ngTemplateOutletContext]="{$implicit: (inputElRef?.nativeElement?.value || '')}"></ng-container>
         </li>
     </ul>
 

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -122,6 +122,14 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     private _focusToInput = false;
     public isFocused = false;
 
+    /** @internal */
+    public get inputText() {
+      if (this.inputElRef && this.inputElRef.nativeElement) {
+        return this.inputElRef.nativeElement.value;
+      }
+      return '';
+    }
+
     constructor(iterableDiffers: IterableDiffers, private sanitizer: DomSanitizer, private cd: ChangeDetectorRef,
                 @Inject(NGX_SELECT_OPTIONS) @Optional() defaultOptions: INgxSelectOptions) {
         Object.assign(this, defaultOptions);


### PR DESCRIPTION
If the search text is not found in available options "not found template" is shown, but missing the possibility to simply get the text.

I've passed it through the `ngTemplateOutletContext`.

It could be useful if you want to add this text as new item with a button as in your example (updated).