### PR TITLE
feat: improve performance

### DIFF
--- a/src/app/lib/ngx-select/ngx-select.classes.ts
+++ b/src/app/lib/ngx-select/ngx-select.classes.ts
@@ -7,7 +7,9 @@ const escapeString = escapeStringNs;
 export class NgxSelectOption implements INgxSelectOption, INgxSelectOptionBase {
     readonly type: TNgxSelectOptionType = 'option';
 
-    constructor(public value: number | string,
+  highlightedText: SafeHtml;
+
+  constructor(public value: number | string,
                 public text: string,
                 public disabled: boolean,
                 public data: any,

--- a/src/app/lib/ngx-select/ngx-select.classes.ts
+++ b/src/app/lib/ngx-select/ngx-select.classes.ts
@@ -8,6 +8,7 @@ export class NgxSelectOption implements INgxSelectOption, INgxSelectOptionBase {
     readonly type: TNgxSelectOptionType = 'option';
 
   highlightedText: SafeHtml;
+  active: boolean;
 
   constructor(public value: number | string,
                 public text: string,

--- a/src/app/lib/ngx-select/ngx-select.component.html
+++ b/src/app/lib/ngx-select/ngx-select.component.html
@@ -92,7 +92,7 @@
                })"
                (click)="optionSelect(option, $event)">
                 <ng-container [ngTemplateOutlet]="templateOption || defaultTemplateOption"
-                              [ngTemplateOutletContext]="{$implicit: option, text: highlightOption(option),
+                              [ngTemplateOutletContext]="{$implicit: option, text: option.highlightedText,
                               index: idxGroup, subIndex: idxOption}"></ng-container>
             </a>
         </li>

--- a/src/app/lib/ngx-select/ngx-select.component.html
+++ b/src/app/lib/ngx-select/ngx-select.component.html
@@ -4,8 +4,7 @@
         'open show': optionsOpened && optionsFiltered.length
      }, multiple === true)"
      (click)="mainClicked($event)" (focusin)="mainClicked($event)"
-     (focus)="focusToInput()" (keydown)="inputKeyDown($event)"
-     (keyup)="mainKeyUp($event)">
+     (focus)="focusToInput()" (keydown)="inputKeyDown($event)">
     <div [ngClass]="{ 'ngx-select__disabled': disabled}"></div>
 
     <!-- single selected item -->
@@ -59,9 +58,7 @@
     <input #input type="text" class="ngx-select__search form-control" [ngClass]="setFormControlSize()"
            *ngIf="checkInputVisibility()"
            [tabindex]="multiple === false? -1: 0"
-           (keydown)="inputKeyDown($event)"
-           (keyup)="inputKeyUp(input.value)"
-           (input)="doInputText(input.value)"
+           (keyup)="inputKeyUp(input.value, $event)"
            [disabled]="disabled"
            [placeholder]="optionsSelected.length? '': placeholder"
            (click)="inputClick(input.value)"
@@ -82,13 +79,13 @@
             <a href="#" #choiceItem class="ngx-select__item dropdown-item"
                *ngFor="let option of (opt.optionsFiltered || [opt]); trackBy: trackByOption; let idxOption = index"
                [ngClass]="{
-                    'ngx-select__item_active active': isOptionActive(option, choiceItem),
+                    'ngx-select__item_active active': option.active,
                     'ngx-select__item_disabled disabled': option.disabled
                }"
                (mouseenter)="onMouseEnter({
                     activeOption: option,
                     filteredOptionList: optionsFiltered,
-                    index: optionsFiltered.indexOf(option)
+                    index: idxOption
                })"
                (click)="optionSelect(option, $event)">
                 <ng-container [ngTemplateOutlet]="templateOption || defaultTemplateOption"

--- a/src/app/lib/ngx-select/ngx-select.component.spec.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.spec.ts
@@ -119,6 +119,12 @@ const createKeyboardEvent = (typeArg: string, code: string) => {
     return customEvent;
 };
 
+const createKeyupEvent = (key: string) => {
+  return new KeyboardEvent('keyup', {
+    key
+  });
+};
+
 describe('NgxSelectComponent', () => {
     let fixture: ComponentFixture<TestNgxSelectComponent>;
     const el = (id: number) => fixture.debugElement.nativeElement.querySelector(`#sel-${id} .ngx-select`);
@@ -677,7 +683,7 @@ describe('NgxSelectComponent', () => {
             formControl(1).click();
             fixture.detectChanges();
             formControlInput(1).value = 'br';
-            formControlInput(1).dispatchEvent(createKeyboardEvent('input', 'keyR'));
+            formControlInput(1).dispatchEvent(createKeyupEvent(''));
             fixture.detectChanges();
             expect(selectItemList(1).length).toBe(3);
             expect(selectItemList(1)[0]).toEqual(selectItemActive(1));
@@ -689,7 +695,7 @@ describe('NgxSelectComponent', () => {
             formControl(1).click();
             fixture.detectChanges();
             formControlInput(1).value = 'br';
-            formControlInput(1).dispatchEvent(createKeyboardEvent('input', 'keyR'));
+            formControlInput(1).dispatchEvent(createKeyupEvent(''));
             fixture.detectChanges();
             fixture.componentInstance.select1.items = items;
             fixture.detectChanges();
@@ -702,7 +708,7 @@ describe('NgxSelectComponent', () => {
             formControl(1).click();
             fixture.detectChanges();
             formControlInput(1).value = '5';
-            formControlInput(1).dispatchEvent(createKeyboardEvent('input', 'key5'));
+            formControlInput(1).dispatchEvent(createKeyupEvent(''));
             fixture.detectChanges();
             expect(selectItemList(1).length).toBe(2);
         });
@@ -716,7 +722,7 @@ describe('NgxSelectComponent', () => {
             formControl(1).click();
             fixture.detectChanges();
             formControlInput(1).value = 'br';
-            formControlInput(1).dispatchEvent(createKeyboardEvent('input', 'keyR'));
+            formControlInput(1).dispatchEvent(createKeyupEvent(''));
             fixture.detectChanges();
             expect(selectItemList(1).length).toBe(3);
         });

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -522,7 +522,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     }
 
     private ensureVisibleElement(element: HTMLElement) {
-      setTimeout(()=>{
+      setTimeout(() => {
         if (this.choiceMenuElRef && this.cacheElementOffsetTop !== element.offsetTop) {
             this.cacheElementOffsetTop = element.offsetTop;
             const container: HTMLElement = this.choiceMenuElRef.nativeElement;
@@ -532,7 +532,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
                 container.scrollTop = this.cacheElementOffsetTop + element.offsetHeight - container.clientHeight;
             }
         }
-      })
+      });
     }
 
     public optionsOpen(search: string = '') {

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -424,12 +424,12 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
 
     /** @internal */
     public inputKeyUp(value: string = '', event: KeyboardEvent ) {
-        if (this.optionsOpened) {
+        if (event.code === this.keyCodeToOptionsClose) {
+          this.optionsClose(/*true*/);
+        } else if (this.optionsOpened) {
           this.typed.emit(value);
         } else if (!this.optionsOpened && value) {
             this.optionsOpen(value);
-        } else if (event.code === this.keyCodeToOptionsClose) {
-            this.optionsClose(/*true*/);
         }
     }
 
@@ -522,7 +522,6 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     }
 
     private ensureVisibleElement(element: HTMLElement) {
-      setTimeout(() => {
         if (this.choiceMenuElRef && this.cacheElementOffsetTop !== element.offsetTop) {
             this.cacheElementOffsetTop = element.offsetTop;
             const container: HTMLElement = this.choiceMenuElRef.nativeElement;
@@ -532,7 +531,6 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
                 container.scrollTop = this.cacheElementOffsetTop + element.offsetHeight - container.clientHeight;
             }
         }
-      });
     }
 
     public optionsOpen(search: string = '') {

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -208,7 +208,19 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
         this.subjOptions
             .combineLatest(this.subjOptionsSelected, this.subjSearchText,
                 (options: TSelectOption[], selectedOptions: NgxSelectOption[], search: string) => {
-                    this.optionsFiltered = this.filterOptions(search, options, selectedOptions);
+                    this.optionsFiltered = this.filterOptions(search, options, selectedOptions)
+                      .map(option => {
+                        if (option instanceof NgxSelectOption) {
+                          option.highlightedText = this.highlightOption(option);
+                        } else if (option instanceof NgxSelectOptGroup) {
+                          option.options.map(x => {
+                            x.highlightedText = this.highlightOption(x);
+                            return x;
+                          });
+                        }
+
+                        return option;
+                      });
                     this.cacheOptionsFilteredFlat = null;
                     this.navigateOption(ENavigation.firstIfOptionActiveInvisible);
                     return selectedOptions;

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -185,22 +185,24 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
                 .toArray()
             )
             .combineLatest(subjActualValue, (optionsFlat: NgxSelectOption[], actualValue: any[]) => {
-                Observable.from(optionsFlat)
-                    .filter((option: NgxSelectOption) => actualValue.indexOf(option.value) !== -1)
-                    .toArray()
-                    .filter((options: NgxSelectOption[]) => {
-                        if (this.keepSelectedItems) {
-                            const optionValues = options.map((option: NgxSelectOption) => option.value);
-                            const keptSelectedOptions = this.subjOptionsSelected.value
-                                .filter((selOption: NgxSelectOption) => optionValues.indexOf(selOption.value) === -1);
-                            options = keptSelectedOptions.concat(options);
-                        }
-                        return !_.isEqual(options, this.subjOptionsSelected.value);
-                    })
-                    .subscribe((options: NgxSelectOption[]) => {
-                      this.subjOptionsSelected.next(options);
-                      this.cd.markForCheck();
-                    });
+              const optionsSelected = [];
+              for (const option of optionsFlat) {
+                if (actualValue.indexOf(option.value) > -1) {
+                  optionsSelected.push(option);
+                }
+              }
+
+              if (this.keepSelectedItems) {
+                const optionValues = optionsSelected.map((option: NgxSelectOption) => option.value);
+                const keptSelectedOptions = this.subjOptionsSelected.value
+                  .filter((selOption: NgxSelectOption) => optionValues.indexOf(selOption.value) === -1);
+                optionsSelected.push(...keptSelectedOptions);
+              }
+
+              if (!_.isEqual(optionsSelected, this.subjOptionsSelected.value)) {
+                this.subjOptionsSelected.next(optionsSelected);
+                this.cd.markForCheck();
+              }
             })
             .subscribe();
 


### PR DESCRIPTION
The performance of the control is good on i5 or i7 machine, but poor on lower devices. Example ARM. This version of the control is 3-6 times faster.

The rxjs solution is beautiful, but the map and filter functions run multiple times on the same collection. I minimalized the modifications, but the performance could be much better if more maps, filters, etc functions were merged.

Summary:
- optimize selected options calculation
- calculate the highlighted text and active flag when filter items
- merge `keydown` and `keyup` events of the container div
- merge `keydown`, 'keyup` and `input` events of the input control