### PR TITLE
any click in input allows multiselect to open

### DIFF
--- a/src/app/lib/ngx-select/ngx-select.component.html
+++ b/src/app/lib/ngx-select/ngx-select.component.html
@@ -37,9 +37,9 @@
     </div>
 
     <!-- multiple selected items -->
-    <div class="ngx-select__selected" *ngIf="multiple === true">
+    <div class="ngx-select__selected" *ngIf="multiple === true" (click)="inputClick(inputElRef && inputElRef['value'])">
         <span *ngFor="let option of optionsSelected; trackBy: trackByOption; let idx = index">
-            <span tabindex="-1" [ngClass]="setBtnSize()"
+            <span tabindex="-1" [ngClass]="setBtnSize()" (click)="$event.stopPropagation()"
                   class="ngx-select__selected-plural btn btn-default btn-secondary btn-xs">
 
                 <ng-container [ngTemplateOutlet]="templateSelectedOption || defaultTemplateOption"

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -84,7 +84,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     @Output() public selectionChanges = new EventEmitter<INgxSelectOption[]>();
 
     @ViewChild('main') protected mainElRef: ElementRef;
-    @ViewChild('input') protected inputElRef: ElementRef;
+    @ViewChild('input') public inputElRef: ElementRef;
     @ViewChild('choiceMenu') protected choiceMenuElRef: ElementRef;
 
     @ContentChild(NgxSelectOptionDirective, {read: TemplateRef}) templateOption: NgxSelectOptionDirective;


### PR DESCRIPTION
User can click anywhere in the select input area to open a dropdown, instead of only on the second row.

Prevents propagation when clicking on an existing entry