### PR TITLE
View destroyed error fix

### DIFF
--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -3,15 +3,15 @@ import {
     Component, ElementRef, EventEmitter, forwardRef, HostListener, IterableDiffer, IterableDiffers, ChangeDetectorRef, ContentChild,
     TemplateRef, Optional, Inject, InjectionToken, ChangeDetectionStrategy, OnDestroy
 } from '@angular/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
-import {Observable, Subject, BehaviorSubject, EMPTY, of, from, merge, combineLatest} from 'rxjs';
-import {tap, filter, map, share, flatMap, toArray, distinctUntilChanged} from 'rxjs/operators';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Observable, Subject, BehaviorSubject, EMPTY, of, from, merge, combineLatest } from 'rxjs';
+import { tap, filter, map, share, flatMap, toArray, distinctUntilChanged } from 'rxjs/operators';
 import * as lodashNs from 'lodash';
 import * as escapeStringNs from 'escape-string-regexp';
-import {NgxSelectOptGroup, NgxSelectOption, TSelectOption} from './ngx-select.classes';
-import {NgxSelectOptionDirective, NgxSelectOptionNotFoundDirective, NgxSelectOptionSelectedDirective} from './ngx-templates.directive';
-import {INgxOptionNavigated, INgxSelectOption, INgxSelectOptions} from './ngx-select.interfaces';
+import { NgxSelectOptGroup, NgxSelectOption, TSelectOption } from './ngx-select.classes';
+import { NgxSelectOptionDirective, NgxSelectOptionNotFoundDirective, NgxSelectOptionSelectedDirective } from './ngx-templates.directive';
+import { INgxOptionNavigated, INgxSelectOption, INgxSelectOptions } from './ngx-select.interfaces';
 
 const _ = lodashNs;
 const escapeString = escapeStringNs;
@@ -85,16 +85,16 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     @Output() public navigated = new EventEmitter<INgxOptionNavigated>();
     @Output() public selectionChanges = new EventEmitter<INgxSelectOption[]>();
 
-    @ViewChild('main', {static: true}) protected mainElRef: ElementRef;
-    @ViewChild('input', {static: false}) public inputElRef: ElementRef;
-    @ViewChild('choiceMenu', {static: false}) protected choiceMenuElRef: ElementRef;
+    @ViewChild('main', { static: true }) protected mainElRef: ElementRef;
+    @ViewChild('input', { static: false }) public inputElRef: ElementRef;
+    @ViewChild('choiceMenu', { static: false }) protected choiceMenuElRef: ElementRef;
 
-    @ContentChild(NgxSelectOptionDirective, {read: TemplateRef, static: true}) templateOption: NgxSelectOptionDirective;
+    @ContentChild(NgxSelectOptionDirective, { read: TemplateRef, static: true }) templateOption: NgxSelectOptionDirective;
 
-    @ContentChild(NgxSelectOptionSelectedDirective, {read: TemplateRef, static: true})
+    @ContentChild(NgxSelectOptionSelectedDirective, { read: TemplateRef, static: true })
     templateSelectedOption: NgxSelectOptionSelectedDirective;
 
-    @ContentChild(NgxSelectOptionNotFoundDirective, {read: TemplateRef, static: true})
+    @ContentChild(NgxSelectOptionNotFoundDirective, { read: TemplateRef, static: true })
     templateOptionNotFound: NgxSelectOptionNotFoundDirective;
 
     public optionsOpened = false;
@@ -249,7 +249,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     }
 
     public setBtnSize() {
-        return {'btn-sm': this.size === 'small', 'btn-lg': this.size === 'large'};
+        return { 'btn-sm': this.size === 'small', 'btn-lg': this.size === 'large' };
     }
 
     public get optionsSelected(): NgxSelectOption[] {
@@ -298,7 +298,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     private navigateOption(navigation: ENavigation) {
         this.optionsFilteredFlat().pipe(
             map<NgxSelectOption[], INgxOptionNavigated>((options: NgxSelectOption[]) => {
-                const navigated: INgxOptionNavigated = {index: -1, activeOption: null, filteredOptionList: options};
+                const navigated: INgxOptionNavigated = { index: -1, activeOption: null, filteredOptionList: options };
                 let newActiveIdx;
                 switch (navigation) {
                     case ENavigation.first:
@@ -362,9 +362,9 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
 
         }
     }
-    
+
     public ngOnDestroy(): void {
-        this.cd.detach(); 
+        this.cd.detach();
     }
 
     public canClearNotMultiple(): boolean {

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -1,7 +1,7 @@
 import {
     AfterContentChecked, DoCheck, Input, Output, ViewChild,
     Component, ElementRef, EventEmitter, forwardRef, HostListener, IterableDiffer, IterableDiffers, ChangeDetectorRef, ContentChild,
-    TemplateRef, Optional, Inject, InjectionToken, ChangeDetectionStrategy
+    TemplateRef, Optional, Inject, InjectionToken, ChangeDetectionStrategy, OnDestroy
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
@@ -44,7 +44,7 @@ function propertyExists(obj: object, propertyName: string) {
         }
     ]
 })
-export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccessor, DoCheck, AfterContentChecked {
+export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccessor, DoCheck, AfterContentChecked, OnDestroy {
     @Input() public items: any[];
     @Input() public optionValueField = 'id';
     @Input() public optionTextField = 'text';
@@ -361,6 +361,10 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
             }
 
         }
+    }
+    
+    public ngOnDestroy(): void {
+        this.cd.detach(); 
     }
 
     public canClearNotMultiple(): boolean {


### PR DESCRIPTION
This PR fixes an error that happens in our production app:

```
Error: ViewDestroyedError: Attempt to use a destroyed view: detectChanges
  at viewDestroyedError (/./node_modules/@angular/core/fesm2015/core.js:25516:1)
  at debugUpdateDirectives (/./node_modules/@angular/core/fesm2015/core.js:39361:1)
  at checkAndUpdateView (/./node_modules/@angular/core/fesm2015/core.js:38376:1)
  at callWithDebugContext (/./node_modules/@angular/core/fesm2015/core.js:39716:1)
  at detectChanges (/./node_modules/@angular/core/fesm2015/core.js:27092:1)
...
(9 additional frame(s) were not displayed)
```

This happens when the `changeDetectorRef` tries to detectChanges on a destroyed view. I added an OnDestroy interface, which implements the detaching of the `changeDetectorRef`.