### PR TITLE
add an option to set the autocomplete value for the input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Any item can be `disabled` for prevent selection. For disable an item add the pr
 | [multiple] | boolean | `false` |  Mode of this component. If set `true` user can select more than one option |
 | [allowClear] | boolean | `false` |  Set to `true` to allow the selection to be cleared. This option only applies to single-value inputs |
 | [placeholder] | string | `''` |  Set to `true` Placeholder text to display when the element has no focus and selected items |
-| [noAutoComplete] | boolean | `false` |  Set to `true` Set to `true` to hide the search input. This option only applies to single-value inputs |
+| [noAutoComplete] | boolean | `false` |  Set to `true` to hide the search input. This option only applies to single-value inputs |
 | [keepSelectedItems] | boolean | `false` | Storing the selected items when the item list is changed |
 | [disabled] | boolean | `false` |  When `true`, it specifies that the component should be disabled |
 | [defaultValue] | any[] | `[]` |  Use to set default value |
@@ -106,6 +106,7 @@ Any item can be `disabled` for prevent selection. For disable an item add the pr
 | autoActiveOnMouseEnter | boolean | true | Automatically activate item when mouse enter on it |
 | isFocused | boolean | false | Makes the component focused |
 | keepSelectMenuOpened | boolean | false | Keeps the select menu opened |
+| autocomplete | string | `'off'` | Sets an autocomplete value for the input field |
 | showOptionNotFoundForEmptyItems | boolean | false | Shows the "Not Found" menu option in case of out of items at all |
 
 | Output  | Description |

--- a/src/app/lib/ngx-select/ngx-select.component.html
+++ b/src/app/lib/ngx-select/ngx-select.component.html
@@ -62,7 +62,7 @@
            [disabled]="disabled"
            [placeholder]="optionsSelected.length? '': placeholder"
            (click)="inputClick(input.value)"
-           autocomplete="off"
+           [autocomplete]="autocomplete"
            autocorrect="off"
            autocapitalize="off"
            spellcheck="false"

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -87,6 +87,7 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     @Input() public showOptionNotFoundForEmptyItems = false;
     @Input() public isFocused = false;
     @Input() public keepSelectMenuOpened = false;
+    @Input() public autocomplete = 'off';
     public keyCodeToRemoveSelected = 'Delete';
     public keyCodeToOptionsOpen = ['Enter', 'NumpadEnter'];
     public keyCodeToOptionsClose = 'Escape';

--- a/src/app/lib/ngx-select/ngx-select.interfaces.ts
+++ b/src/app/lib/ngx-select/ngx-select.interfaces.ts
@@ -48,4 +48,5 @@ export interface INgxSelectOptions {
     keyCodeToNavigateNext?: string;
     keyCodeToNavigateLast?: string;
     isFocused?: boolean;
+    autocomplete?: string;
 }


### PR DESCRIPTION
Browsers do not disable autocomplete if you set it to off, for example in Chrome. When you use ngx-select with a list and a search field, once you put the focus on the field, the browser shows its own autocomplete list which covers the list of ngx-select. To disable to list you can use `autocomplete="blabla"`. This pull request allows you to do that.

```
<ngx-select
     [items]="items"
     optionTextField="textProp"
     optionValueField="valueProp"
     autocomplete="blabla">
</ngx-select>
```