### PR TITLE
feat: add option to disable safe html

### DIFF
--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -88,6 +88,8 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
     @Input() public keepSelectMenuOpened = false;
     @Input() public autocomplete = 'off';
     @Input() public dropDownMenuOtherClasses = '';
+    @Input() public noSanitize = false;
+
     public keyCodeToRemoveSelected = 'Delete';
     public keyCodeToOptionsOpen = ['Enter', 'NumpadEnter'];
     public keyCodeToOptionsClose = 'Escape';
@@ -473,6 +475,10 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
 
     /** @internal */
     public sanitize(html: string): SafeHtml {
+        if(!this.noSanitize) {
+            return html || null;
+        }
+        
         return html ? this.sanitizer.bypassSecurityTrustHtml(html) : null;
     }
 

--- a/src/app/lib/ngx-select/ngx-select.component.ts
+++ b/src/app/lib/ngx-select/ngx-select.component.ts
@@ -475,10 +475,10 @@ export class NgxSelectComponent implements INgxSelectOptions, ControlValueAccess
 
     /** @internal */
     public sanitize(html: string): SafeHtml {
-        if(!this.noSanitize) {
+        if(this.noSanitize) {
             return html || null;
         }
-        
+
         return html ? this.sanitizer.bypassSecurityTrustHtml(html) : null;
     }
 


### PR DESCRIPTION
Because all `text` is automatically marked as safe html, user input is now vulnerable to XSS attacks on other users. Therefore I added the option to disable the sanitization in the `sanitize()` function if needed

Please merge and deploy this asap as this is a huge security risk.

Personally I would opt for it to be disabled by default and enabled by the developer if needed, but that would require a major version.