### PR TITLE
Add appendTo option in INgxSelectOptions and make keepSelectedItems optional

### DIFF
--- a/src/app/lib/ngx-select/ngx-select.interfaces.ts
+++ b/src/app/lib/ngx-select/ngx-select.interfaces.ts
@@ -50,4 +50,5 @@ export interface INgxSelectOptions {
     isFocused?: boolean;
     autocomplete?: string;
     dropDownMenuOtherClasses?: string;
+    appendTo?: string;
 }

--- a/src/app/lib/ngx-select/ngx-select.interfaces.ts
+++ b/src/app/lib/ngx-select/ngx-select.interfaces.ts
@@ -37,7 +37,7 @@ export interface INgxSelectOptions {
     autoSelectSingleOption?: boolean;
     autoClearSearch?: boolean;
     noResultsFound?: string;
-    keepSelectedItems: boolean;
+    keepSelectedItems?: boolean;
     size?: 'small' | 'default' | 'large';
     keyCodeToRemoveSelected?: string;
     keyCodeToOptionsOpen?: string | string[];


### PR DESCRIPTION
I had forgotten to add the appendTo option in the options interface. I also noticed that the only non-optional option was keepSelectedItems, which is optional in the component, so I think it should be here too.